### PR TITLE
Improved testing of optional attributes, enforce valid SCOM Management pack IDs

### DIFF
--- a/Index.json.tests.ps1
+++ b/Index.json.tests.ps1
@@ -65,11 +65,13 @@ Describe "Index.json" -Tag $location {
             }
 
             It "Pack $name has valid IsActive" {
-                $isActive = $pack.IsActive
+                $isActive = $null
                 
                 # Treat as true if not specified, as the catalog does
                 if (($pack.PSObject.Properties | Select-Object -ExpandProperty Name) -notcontains 'IsActive') {
                     $isActive = $true
+                } else {
+                    $isActive = $pack.IsActive
                 }
 
                 $isActive | Should BeOfType System.Boolean

--- a/Index.json.tests.ps1
+++ b/Index.json.tests.ps1
@@ -63,6 +63,17 @@ Describe "Index.json" -Tag $location {
                 $path = Join-Path $pwd $name
                 $path | Should Exist
             }
+
+            It "Pack $name has valid IsActive" {
+                $isActive = $pack.IsActive
+                
+                # Treat as true if not specified, as the catalog does
+                if (($pack.PSObject.Properties | Select-Object -ExpandProperty Name) -notcontains 'IsActive') {
+                    $isActive = $true
+                }
+
+                $isActive | Should BeOfType System.Boolean
+            }
         }
     }
 }

--- a/Index.json.tests.ps1
+++ b/Index.json.tests.ps1
@@ -54,6 +54,11 @@ Describe "Index.json" -Tag $location {
         
         foreach ($pack in $json) {
             $name = $pack.ManagementPackSystemName
+            
+            It "Pack $name has valid ManagementPackSystemName" {
+                $pack.ManagementPackSystemName | Should Match '^[A-Za-z_][A-Za-z0-9_\.]{0,255}$'
+            }
+
             It "Pack $name matches folder name" {
                 $path = Join-Path $pwd $name
                 $path | Should Exist

--- a/Pack.tests.template.ps1
+++ b/Pack.tests.template.ps1
@@ -51,8 +51,9 @@ foreach ($packFile in $packFiles) {
                 $contents | Should Not BeNullOrEmpty
             }
 
-            It "Has a ManagementPackSystemName" {
+            It "Has a valid ManagementPackSystemName" {
                 $json.ManagementPackSystemName | Should Not BeNullOrEmpty
+                $json.ManagementPackSystemName | Should Match '^[A-Za-z_][A-Za-z0-9_\.]{0,255}$'
             }
 
             It "ManagementPackSystemName matches folder name" {

--- a/Pack.tests.template.ps1
+++ b/Pack.tests.template.ps1
@@ -84,12 +84,15 @@ foreach ($packFile in $packFiles) {
             }
     
             It "Has IsFree" {
-                $IsFree = $json.IsFree
+                $IsFree = $null
                 
                 # Treat as false if not specified, as the catalog does
                 if (($json.PSObject.Properties | Select-Object -ExpandProperty Name) -notcontains 'IsFree') {
                     $IsFree = $false
+                } else {
+                    $IsFree = $json.IsFree
                 }
+                
                 $IsFree | Should BeOfType System.Boolean
             }
     

--- a/Pack.tests.template.ps1
+++ b/Pack.tests.template.ps1
@@ -84,7 +84,13 @@ foreach ($packFile in $packFiles) {
             }
     
             It "Has IsFree" {
-                $json.IsFree | Should BeOfType System.Boolean
+                $IsFree = $json.IsFree
+                
+                # Treat as false if not specified, as the catalog does
+                if (($json.PSObject.Properties | Select-Object -ExpandProperty Name) -notcontains 'IsFree') {
+                    $IsFree = $false
+                }
+                $IsFree | Should BeOfType System.Boolean
             }
     
             It "Has an array of Tags" {


### PR DESCRIPTION
## Description

Pretty simple one this, updated the tests based on the Wiki updates.

* Index.json __IsActive__ property is now tested and enforced as a boolean.  Test will pass if property omitted.
* Details.json __IsFree__ property test will pass if property is omitted (treated as the default of false)
* All tests related to __ManagementPackSystemName__ validity now enforce that this value matches the _ManagementPackUniqueIdentifier_ constraint applied by SCOM to MP identifiers.