### PR TITLE
Added SCUtils APC UPS free mp

### DIFF
--- a/Index.json
+++ b/Index.json
@@ -87,6 +87,9 @@
         "ManagementPackSystemName":  "SCOM.Task.Collection.SCOMfaq"
     },
     {
+        "ManagementPackSystemName": "SCUtils.APC.UPS"
+    },
+    {
         "ManagementPackSystemName":  "Security.Monitoring"
     },
     {

--- a/SCUtils.APC.UPS/ReadMe.md
+++ b/SCUtils.APC.UPS/ReadMe.md
@@ -1,0 +1,18 @@
+## SCUtils Monitoring for APC UPS
+
+Many our customers utilizes uninterruptible power supplies made by [APC by Schneider Electric](http://www.apc.com/) in their server rooms. SCUtils team has created a solution that helps managing [APC Smart-UPS](http://www.apc.com/smartups/)_TM_ series. Comparing with other solutions, SCUtils Monitoring for APC UPS and EMU devices has the following benefits:
+
+* Multiple reports (availability, parameter’s graphs, time on battery, humidity, temperature, etc)
+* Adjustable dashboard
+* Monitoring environmental sensors – humidity and temperature
+* A support for APC Environmental Monitoring Units/Systems with a system OID 1.3.6.1.4.1.318.1.3.8.3. (excluding APC NetBotz 200)
+* Overrides
+* Last battery replacement date
+
+Our solution is compatible with Microsoft System Center 2012 R2 Operations Manager. It is completely free and available for all registered visitors from [Downloads](https://www.scutils.com/downloads) page.
+
+We don't have an opportunity to test each type of APC devices so your feedback will be highly appreciated.
+
+[SCUtils Monitoring APC UPS Guide v1.0](https://www.scutils.com/documents/SCUtils%20Monitoring%20APC%20UPS%20Guide%20v1.0.pdf)
+
+APC is a trademark of the Schneider Electric. All other trademarks are property of their respective owners.

--- a/SCUtils.APC.UPS/details.json
+++ b/SCUtils.APC.UPS/details.json
@@ -1,0 +1,17 @@
+{
+    "ManagementPackSystemName": "SCUtils.APC.UPS",
+    "ManagementPackDisplayName": "SCUtils APC UPS",
+    "URL": "https://www.scutils.com/products/apcupsmonitoring",
+    "Version": "1.6.0.1",
+    "Author": "SCUtils",
+    "IsFree": true,
+    "Description": "SCUtils team have created a solution that helps managing APC Smart-UPSTM series uninterruptible power supplies made by Schneider Electric in their server rooms.",
+    "Tags": [
+        "UPS",
+        "EMU",
+        "APC",
+        "SCUtils",
+        "Schneider Electric",
+        "SNMP"
+    ]
+}


### PR DESCRIPTION
What does this add/fix? 
------------------------------
Adds the free SCUtils APC UPS monitoring MP.

Does this close any currently open issues?
------------------------------------------
Management pack referenced in #35 

Any other comments?
-------------------
There are four other MPs available from SCUtils that also monitor APC products - these are all paid solutions though (that do have a 15 day free trial).  May be worth adding those after further investigation/verification by someone using them?