### PR TITLE
Rename Management Pack

### DIFF
--- a/ABC.F5.BIGIP/details.json
+++ b/ABC.F5.BIGIP/details.json
@@ -1,8 +1,8 @@
 {
-  "ManagementPackSystemName": "ABC.F5.BIGIP",
-  "ManagementPackDisplayName": "ABC F5 BIGIP ",
+  "ManagementPackSystemName": "NetSec.F5.BIGIP",
+  "ManagementPackDisplayName": "NetSec F5 BIGIP ",
   "URL": "https://github.com/Juanito99/F5_BIGIP_OpsMgr",
-  "Version": "1.0.0.77",
+  "Version": "1.0.0.117",
   "Author": "Ruben Zimmerman",
   "Description": "A management pack to monitor F5 BIGIP with OpsMgr",
   "IsFree": true,


### PR DESCRIPTION
Would like to rename it. Instead of ABC - NetSec

Thanks for helping contribute to the MP Catalog.  Please check the contribution guidelines with any questions, then fill out the below blanks.

What does this add/fix? 
------------------------------
It changes the name of the management pack.

Does this close any currently open issues?
------------------------------------------
No

Any other comments?
-------------------
Personal preference