### PR TITLE
Ep rip technet

### DIFF
--- a/Aquilaweb.Support.PendingReboot/details.json
+++ b/Aquilaweb.Support.PendingReboot/details.json
@@ -1,7 +1,7 @@
 {
   "ManagementPackSystemName": "Aquilaweb.Support.PendingReboot",
   "ManagementPackDisplayName": "Aquilaweb Support - Pending Reboots",
-  "URL": "https://gallery.technet.microsoft.com/SCOM-Pending-Reboot-b0f14d86",
+  "URL": "https://web.archive.org/web/20200318045815/https://gallery.technet.microsoft.com/SCOM-Pending-Reboot-b0f14d86",
   "Version": "1.0.0.4",
   "Author": "David Allen",
   "IsFree": true,

--- a/Docker.Unix.Monitoring/details.json
+++ b/Docker.Unix.Monitoring/details.json
@@ -1,7 +1,7 @@
 ﻿{
     "ManagementPackSystemName":  "Docker.Unix.Monitoring",
     "ManagementPackDisplayName":  "UNIX/Linux Docker Monitoring",
-    "URL":  "https://gallery.technet.microsoft.com/UNIXLinux-Docker-ecc6d024",
+    "URL":  "https://web.archive.org/web/20200318060112/https://gallery.technet.microsoft.com/UNIXLinux-Docker-ecc6d024",
     "Version":  "1.0.0.0",
     "Author":  "bobgreen84",
     "Description":  "This management pack allows you to monitor on-premise  Docker containers hosted on UNIX/Linux computers. It has basic functionality: Daemon state monitoring Container state monitoring Collects container CPU usage Collects container memory usage For montitoring your Docker environment",

--- a/HealthServiceStore.Monitoring/details.json
+++ b/HealthServiceStore.Monitoring/details.json
@@ -1,7 +1,7 @@
 {
 	"ManagementPackSystemName": "HealthServiceStore.Monitoring",
 	"ManagementPackDisplayName": "Health Service Store Monitoring",
-	"URL": "https://blogs.technet.microsoft.com/jimmyharper/2015/09/02/management-pack-to-monitor-and-reduce-health-service-store-size/",
+	"URL": "https://web.archive.org/web/20190420010131/https://blogs.technet.microsoft.com/jimmyharper/2015/09/02/management-pack-to-monitor-and-reduce-health-service-store-size/",
 	"Version": "1.0.0.13",
 	"Author": "Jimmy Harper",
 	"IsFree": true,

--- a/Microsoft.SQLServer.RunAs.Addendum.Library/details.json
+++ b/Microsoft.SQLServer.RunAs.Addendum.Library/details.json
@@ -1,8 +1,8 @@
 {
     "ManagementPackSystemName":  "Microsoft.SQLServer.RunAs.Addendum.Library",
     "ManagementPackDisplayName":  "Microsoft SQL Server RunAs Addendum Library Management Pack",
-    "URL":  "https://gallery.technet.microsoft.com/SQL-Server-RunAs-Addendum-0c183c32",
-    "Version":  "7.0.0.0",
+    "URL":  "https://github.com/thekevinholman/SQLRunAsAddendum",
+    "Version":  "7.0.32.0",
     "Author":  "Kevin Holman",
     "Description":  "This is a SCOM management pack for Operations Manager 2012 and 2016, which will ease the burden of SQL RunAs Accounts.",
     "IsFree":  true,

--- a/Microsoft.SystemCenter.Internal.Addendum/details.json
+++ b/Microsoft.SystemCenter.Internal.Addendum/details.json
@@ -1,7 +1,7 @@
 {
     "ManagementPackSystemName":  "Microsoft.SystemCenter.Internal.Addendum",
     "ManagementPackDisplayName":  "SCOM Agent Version Addendum Pack",
-    "URL":  "https://gallery.technet.microsoft.com/SCOM-Agent-Version-b0bbdfb3",
+    "URL":  "https://github.com/thekevinholman/SCOM.Agent.Version.Addendum.Management.Pack",
     "Version":  "1.0.0.0",
     "Author":  "Kevin Holman",
     "Description":  "This MP sample will change the HealthService version property to discover the actual agent version including UR level, so you can easily know which agents are up to date in the \"Administration\\Agent Managed\" view in the SCOM Console.",

--- a/Microsoft.Windows.Server.AD.2016.Monitoring.Addendum/details.json
+++ b/Microsoft.Windows.Server.AD.2016.Monitoring.Addendum/details.json
@@ -1,7 +1,7 @@
 ﻿{
     "ManagementPackSystemName":  "Microsoft.Windows.Server.AD.2016.Monitoring.Addendum",
     "ManagementPackDisplayName":  "SCOM AD Directory Services Addendum",
-    "URL":  "https://gallery.technet.microsoft.com/SCOM-AD-Directory-Addendum-22d0473a",
+    "URL":  "https://web.archive.org/web/20200727124904/https://gallery.technet.microsoft.com/SCOM-AD-Directory-Addendum-22d0473a",
     "Version":  "1.0.0.1",
     "Author":  "kjustin1996",
     "Description":  "This Addendum MP will add Recovery tasks to AD DS Service Monitors.  The recovery tasks verify service state, start \u0027not running\u0027 services, and recalculates health. This will avoid common rework if/when services go down.",

--- a/MultiHome.ManagementGroup.Automator/ReadMe.md
+++ b/MultiHome.ManagementGroup.Automator/ReadMe.md
@@ -14,4 +14,4 @@ This is provided AS-IS, as an example only, and contains no warranty. The MP sho
 
 Have fun!
 
-https://docs.microsoft.com/en-us/archive/blogs/cchamp/multi-home-management-group-automation-mp
+<https://docs.microsoft.com/en-us/archive/blogs/cchamp/multi-home-management-group-automation-mp>

--- a/MultiHome.ManagementGroup.Automator/ReadMe.md
+++ b/MultiHome.ManagementGroup.Automator/ReadMe.md
@@ -14,4 +14,4 @@ This is provided AS-IS, as an example only, and contains no warranty. The MP sho
 
 Have fun!
 
-http://blogs.technet.com/b/cchamp/archive/2015/09/09/multi-home-management-group-automation-mp.aspx
+https://docs.microsoft.com/en-us/archive/blogs/cchamp/multi-home-management-group-automation-mp

--- a/SAMPLE.OPERATIONSMANAGER.2016.UPGRADE/details.json
+++ b/SAMPLE.OPERATIONSMANAGER.2016.UPGRADE/details.json
@@ -1,7 +1,7 @@
 {
   "ManagementPackSystemName": "SAMPLE.OPERATIONSMANAGER.2016.UPGRADE",
   "ManagementPackDisplayName": "SC Operations Manager Upgrade Helper MP (2012 R2 --> 2016)",
-  "URL": "https://gallery.technet.microsoft.com/Sample-Management-Pack-fd15caa7",
+  "URL": "https://web.archive.org/web/20210118234859/https://gallery.technet.microsoft.com/Sample-Management-Pack-fd15caa7",
   "Version": "1.0.2.38",
   "Author": "Wei H Lim",
   "IsFree": true,

--- a/SCOM.Management/ReadMe.md
+++ b/SCOM.Management/ReadMe.md
@@ -1,4 +1,4 @@
-**Agent Management Pack � Making a SCOM Admin�s life a little easier**
+**Agent Management Pack - Making a SCOM Admin's life a little easier**
 
 This is a Management Pack that eases the administrative burdens in SCOM.  It allows you to have a lot of handy discovered properties, and includes tasks that allow you to delegate administrative actions to your users.  It also serves as a good example MP on how to write classes, discoveries, and most importantly many task examples for command line, VBscript, and PowerShell.
 
@@ -13,38 +13,38 @@ https://kevinholman.com/2017/05/09/scom-management-mp-making-a-scom-admins-life-
 
 Version History:
 
-1.0.0.65 – Initial Release
-1.0.0.72 – Updated with additional properties and dual versions for safer tasks.
-1.0.0.73 – Corrected minor bug in script names in export event log task
-1.0.0.75 – Updated to support SCOM 2012R2 UR13 and SCOM 2016 UR3 in update rollup discovery
-1.0.0.77 – Updated OS Version discovery to PowerShell to better handle WS2016 and Windows 10
-7.0.0.4 – Major Re-write to include Server Roles, add OMS workspaces, UR levels
-7.0.0.20 – Renamed Views, Added Health Service Watcher View, Added Agent install and delete tasks, Added install path property
-7.0.0.27 – Added AD Integration discovered property and tasks to enable/disable AD integration
-7.0.0.33 – Added APM installed discovery to find agents that need NOAPM reinstall, Added Tasks for Agent Delete, and Set IsManualyInstalled to false, Added view for HealthService objects
-7.0.0.42 – Added discovery for OMS proxy, Added tasks for OMS Workspace ADD and REMOVE, Minor bug fixes to Agent Properties powershell discovery.
-7.0.0.45 – Bug fixes, Added properties for OMS, Added tasks for OMS, Changes to views based on customer requests
-7.0.0.46 – Updated server properties discovery to properly detect UR level on Gateways
-7.0.0.47 – Updated to support discovery of SCOM 2016 UR4
-7.0.0.50 – Updated for SCOM 2012 R2 UR14
-7.0.0.51 – Updated for SCOM 2016 UR5
-7.0.0.53 – Updated for TLS 1.2 support
-7.0.0.54 – Added OS/CPU Architecture property
-7.0.0.58 – Added IP address and Port availability check
-7.0.0.59 – Added support for SCOM UR6
-7.0.0.62 – Fixed bugs for UR6 display, Added properties for certificates such as expiration, thumbprint, issuer
-7.0.0.63 – Added tasks for HSLockdown, Added preliminary support for SCOM 2019
-7.0.0.64 – Added support for SCOM 2019 RTM
-7.0.0.65 – Added support for SCOM 2016 UR7
-7.0.0.66 – Added support for SCOM 2016 UR8, and added support for US Government Cloud Type for onboarding Log Analytics direct agent configuration (OMS Workspace)
-10.19.10311.0 – Added support for SCOM 2019 UR1
-10.19.10311.2 – Added support for SCOM 2016 UR9
-10.19.10349.0 – Added support for SCOM 2019 Post UR1 Hotfix. Fixed bug when a management server config file is huge and the script runs out of resources getting XML content.
-10.19.10407.0 – Added support for SCOM 2019 UR2
-10.19.10407.1 - Minor bug fix with quotation marks
-10.19.10407.2 - Added support for SCOM 2016 UR10. Added task to approve agent pending actions
-10.19.10407.3 - Fixed issue getting Agent version when SCOM agent path in registry is incorrect. Added .NET version property. Added MSOLEDBSQL Property.
-10.19.10407.5 - Added monitor for KB4601269 Event Log Security which was released as a post-UR2 hotfix
-10.19.10505.0 - Added support for SCOM 2019 UR3
-10.19.10552.0 - Added support for KB5006871 and KB5005527
-10.19.10552.1 - Added support for detection of KB5005527 on GW and Agents
+* 1.0.0.65 – Initial Release
+* 1.0.0.72 – Updated with additional properties and dual versions for safer tasks.
+* 1.0.0.73 – Corrected minor bug in script names in export event log task
+* 1.0.0.75 – Updated to support SCOM 2012R2 UR13 and SCOM 2016 UR3 in update rollup discovery
+* 1.0.0.77 – Updated OS Version discovery to PowerShell to better handle WS2016 and Windows 10
+* 7.0.0.4 – Major Re-write to include Server Roles, add OMS workspaces, UR levels
+* 7.0.0.20 – Renamed Views, Added Health Service Watcher View, Added Agent install and delete tasks, Added install path property
+* 7.0.0.27 – Added AD Integration discovered property and tasks to enable/disable AD integration
+* 7.0.0.33 – Added APM installed discovery to find agents that need NOAPM reinstall, Added Tasks for Agent Delete, and Set IsManualyInstalled to false, Added view for * HealthService objects
+* 7.0.0.42 – Added discovery for OMS proxy, Added tasks for OMS Workspace ADD and REMOVE, Minor bug fixes to Agent Properties powershell discovery.
+* 7.0.0.45 – Bug fixes, Added properties for OMS, Added tasks for OMS, Changes to views based on customer requests
+* 7.0.0.46 – Updated server properties discovery to properly detect UR level on Gateways
+* 7.0.0.47 – Updated to support discovery of SCOM 2016 UR4
+* 7.0.0.50 – Updated for SCOM 2012 R2 UR14
+* 7.0.0.51 – Updated for SCOM 2016 UR5
+* 7.0.0.53 – Updated for TLS 1.2 support
+* 7.0.0.54 – Added OS/CPU Architecture property
+* 7.0.0.58 – Added IP address and Port availability check
+* 7.0.0.59 – Added support for SCOM UR6
+* 7.0.0.62 – Fixed bugs for UR6 display, Added properties for certificates such as expiration, thumbprint, issuer
+* 7.0.0.63 – Added tasks for HSLockdown, Added preliminary support for SCOM 2019
+* 7.0.0.64 – Added support for SCOM 2019 RTM
+* 7.0.0.65 – Added support for SCOM 2016 UR7
+* 7.0.0.66 – Added support for SCOM 2016 UR8, and added support for US Government Cloud Type for onboarding Log Analytics direct agent configuration (OMS Workspace)
+* 10.19.10311.0 – Added support for SCOM 2019 UR1
+* 10.19.10311.2 – Added support for SCOM 2016 UR9
+* 10.19.10349.0 – Added support for SCOM 2019 Post UR1 Hotfix. Fixed bug when a management server config file is huge and the script runs out of resources getting XML content.
+* 10.19.10407.0 – Added support for SCOM 2019 UR2
+* 10.19.10407.1 - Minor bug fix with quotation marks
+* 10.19.10407.2 - Added support for SCOM 2016 UR10. Added task to approve agent pending actions
+* 10.19.10407.3 - Fixed issue getting Agent version when SCOM agent path in registry is incorrect. Added .NET version property. Added MSOLEDBSQL Property.
+* 10.19.10407.5 - Added monitor for KB4601269 Event Log Security which was released as a post-UR2 hotfix
+* 10.19.10505.0 - Added support for SCOM 2019 UR3
+* 10.19.10552.0 - Added support for KB5006871 and KB5005527
+* 10.19.10552.1 - Added support for detection of KB5005527 on GW and Agents

--- a/SCOM.Management/ReadMe.md
+++ b/SCOM.Management/ReadMe.md
@@ -1,4 +1,4 @@
-**Agent Management Pack � Making a SCOM Admin�s life a little easier**
+**Agent Management Pack � Making a SCOM Admin�s life a little easier**
 
 This is a Management Pack that eases the administrative burdens in SCOM.  It allows you to have a lot of handy discovered properties, and includes tasks that allow you to delegate administrative actions to your users.  It also serves as a good example MP on how to write classes, discoveries, and most importantly many task examples for command line, VBscript, and PowerShell.
 
@@ -13,34 +13,38 @@ https://kevinholman.com/2017/05/09/scom-management-mp-making-a-scom-admins-life-
 
 Version History:
 
-* 1.0.0.65 - Initial Release
-* 1.0.0.72 - Updated with additional properties and dual versions for safer tasks.
-* 1.0.0.73 - Corrected minor bug in script names in export event log task
-* 1.0.0.75 - Updated to support SCOM 2012R2 UR13 and SCOM 2016 UR3 in update rollup discovery
-* 1.0.0.77 - Updated OS Version discovery to PowerShell to better handle WS2016 and Windows 10
-* 7.0.0.4 - Major Re-write to include Server Roles, add OMS workspaces, UR levels
-* 7.0.0.20 - Renamed Views, Added Health Service Watcher View, Added Agent install and delete tasks, Added install path property
-* 7.0.0.27 - Added AD Integration discovered property and tasks to enable/disable AD integration
-* 7.0.0.33 - Added APM installed discovery to find agents that need NOAPM reinstall, Added Tasks for Agent Delete, and Set IsManualyInstalled to false, Added view for HealthService objects
-* 7.0.0.42 - Added discovery for OMS proxy, Added tasks for OMS Workspace ADD and REMOVE, Minor bug fixes to Agent Properties powershell discovery.
-* 7.0.0.45 - Bug fixes, Added properties for OMS, Added tasks for OMS, Changes to views based on customer requests
-* 7.0.0.46 - Updated server properties discovery to properly detect UR level on Gateways
-* 7.0.0.47 - Updated to support discovery of SCOM 2016 UR4
-* 7.0.0.50 - Updated for SCOM 2012 R2 UR14
-* 7.0.0.51 - Updated for SCOM 2016 UR5
-* 7.0.0.53 - Updated for TLS 1.2 support
-* 7.0.0.54 - Added OS/CPU Architecture property
-* 7.0.0.58 - Added IP address and Port availability check
-* 7.0.0.59 - Added support for SCOM UR6
-* 7.0.0.62 - Fixed bugs for UR6 display, Added properties for certificates such as expiration, thumbprint, issuer
-* 7.0.0.63 - Added tasks for HSLockdown, Added preliminary support for SCOM 2019
-* 7.0.0.64 - Added support for SCOM 2019 RTM
-* 7.0.0.65 - Added support for SCOM 2016 UR7
-* 7.0.0.66 - Added support for SCOM 2016 UR8, and added support for US Government Cloud Type for onboarding Log Analytics direct agent configuration (OMS Workspace)
-* 10.19.10311.0 - Added support for SCOM 2019 UR1
-* 10.19.10311.2 - Added support for SCOM 2016 UR9
-* 10.19.10349.0 - Added support for SCOM 2019 Post UR1 Hotfix.  Fixed bug when a management server config file is huge and the script runs out of resources getting XML content.
-* 10.19.10407.0 - Added support for SCOM 2019 UR2
-* 10.19.10407.1 - Minor bug fix with quotation marks
-* 10.19.10407.2 - Added support for SCOM 2016 UR10.  Added task to approve agent pending actions
-* 10.19.10407.3 - Fixed issue getting Agent version when SCOM agent path in registry is incorrect.  Added .NET version property.  Added MSOLEDBSQL Property.
+1.0.0.65 – Initial Release
+1.0.0.72 – Updated with additional properties and dual versions for safer tasks.
+1.0.0.73 – Corrected minor bug in script names in export event log task
+1.0.0.75 – Updated to support SCOM 2012R2 UR13 and SCOM 2016 UR3 in update rollup discovery
+1.0.0.77 – Updated OS Version discovery to PowerShell to better handle WS2016 and Windows 10
+7.0.0.4 – Major Re-write to include Server Roles, add OMS workspaces, UR levels
+7.0.0.20 – Renamed Views, Added Health Service Watcher View, Added Agent install and delete tasks, Added install path property
+7.0.0.27 – Added AD Integration discovered property and tasks to enable/disable AD integration
+7.0.0.33 – Added APM installed discovery to find agents that need NOAPM reinstall, Added Tasks for Agent Delete, and Set IsManualyInstalled to false, Added view for HealthService objects
+7.0.0.42 – Added discovery for OMS proxy, Added tasks for OMS Workspace ADD and REMOVE, Minor bug fixes to Agent Properties powershell discovery.
+7.0.0.45 – Bug fixes, Added properties for OMS, Added tasks for OMS, Changes to views based on customer requests
+7.0.0.46 – Updated server properties discovery to properly detect UR level on Gateways
+7.0.0.47 – Updated to support discovery of SCOM 2016 UR4
+7.0.0.50 – Updated for SCOM 2012 R2 UR14
+7.0.0.51 – Updated for SCOM 2016 UR5
+7.0.0.53 – Updated for TLS 1.2 support
+7.0.0.54 – Added OS/CPU Architecture property
+7.0.0.58 – Added IP address and Port availability check
+7.0.0.59 – Added support for SCOM UR6
+7.0.0.62 – Fixed bugs for UR6 display, Added properties for certificates such as expiration, thumbprint, issuer
+7.0.0.63 – Added tasks for HSLockdown, Added preliminary support for SCOM 2019
+7.0.0.64 – Added support for SCOM 2019 RTM
+7.0.0.65 – Added support for SCOM 2016 UR7
+7.0.0.66 – Added support for SCOM 2016 UR8, and added support for US Government Cloud Type for onboarding Log Analytics direct agent configuration (OMS Workspace)
+10.19.10311.0 – Added support for SCOM 2019 UR1
+10.19.10311.2 – Added support for SCOM 2016 UR9
+10.19.10349.0 – Added support for SCOM 2019 Post UR1 Hotfix. Fixed bug when a management server config file is huge and the script runs out of resources getting XML content.
+10.19.10407.0 – Added support for SCOM 2019 UR2
+10.19.10407.1 - Minor bug fix with quotation marks
+10.19.10407.2 - Added support for SCOM 2016 UR10. Added task to approve agent pending actions
+10.19.10407.3 - Fixed issue getting Agent version when SCOM agent path in registry is incorrect. Added .NET version property. Added MSOLEDBSQL Property.
+10.19.10407.5 - Added monitor for KB4601269 Event Log Security which was released as a post-UR2 hotfix
+10.19.10505.0 - Added support for SCOM 2019 UR3
+10.19.10552.0 - Added support for KB5006871 and KB5005527
+10.19.10552.1 - Added support for detection of KB5005527 on GW and Agents

--- a/SCOM.Management/ReadMe.md
+++ b/SCOM.Management/ReadMe.md
@@ -21,7 +21,7 @@ Version History:
 * 7.0.0.4 – Major Re-write to include Server Roles, add OMS workspaces, UR levels
 * 7.0.0.20 – Renamed Views, Added Health Service Watcher View, Added Agent install and delete tasks, Added install path property
 * 7.0.0.27 – Added AD Integration discovered property and tasks to enable/disable AD integration
-* 7.0.0.33 – Added APM installed discovery to find agents that need NOAPM reinstall, Added Tasks for Agent Delete, and Set IsManualyInstalled to false, Added view for * HealthService objects
+* 7.0.0.33 – Added APM installed discovery to find agents that need NOAPM reinstall, Added Tasks for Agent Delete, and Set IsManualyInstalled to false, Added view for HealthService objects
 * 7.0.0.42 – Added discovery for OMS proxy, Added tasks for OMS Workspace ADD and REMOVE, Minor bug fixes to Agent Properties powershell discovery.
 * 7.0.0.45 – Bug fixes, Added properties for OMS, Added tasks for OMS, Changes to views based on customer requests
 * 7.0.0.46 – Updated server properties discovery to properly detect UR level on Gateways
@@ -39,11 +39,11 @@ Version History:
 * 7.0.0.66 – Added support for SCOM 2016 UR8, and added support for US Government Cloud Type for onboarding Log Analytics direct agent configuration (OMS Workspace)
 * 10.19.10311.0 – Added support for SCOM 2019 UR1
 * 10.19.10311.2 – Added support for SCOM 2016 UR9
-* 10.19.10349.0 – Added support for SCOM 2019 Post UR1 Hotfix. Fixed bug when a management server config file is huge and the script runs out of resources getting XML content.
+* 10.19.10349.0 – Added support for SCOM 2019 Post UR1 Hotfix.  Fixed bug when a management server config file is huge and the script runs out of resources getting XML content.
 * 10.19.10407.0 – Added support for SCOM 2019 UR2
 * 10.19.10407.1 - Minor bug fix with quotation marks
-* 10.19.10407.2 - Added support for SCOM 2016 UR10. Added task to approve agent pending actions
-* 10.19.10407.3 - Fixed issue getting Agent version when SCOM agent path in registry is incorrect. Added .NET version property. Added MSOLEDBSQL Property.
+* 10.19.10407.2 - Added support for SCOM 2016 UR10.  Added task to approve agent pending actions
+* 10.19.10407.3 - Fixed issue getting Agent version when SCOM agent path in registry is incorrect.  Added .NET version property.  Added MSOLEDBSQL Property.
 * 10.19.10407.5 - Added monitor for KB4601269 Event Log Security which was released as a post-UR2 hotfix
 * 10.19.10505.0 - Added support for SCOM 2019 UR3
 * 10.19.10552.0 - Added support for KB5006871 and KB5005527

--- a/SCOM.Management/ReadMe.md
+++ b/SCOM.Management/ReadMe.md
@@ -5,7 +5,7 @@ This is a Management Pack that eases the administrative burdens in SCOM.  It all
 ## Resources
 
 https://kevinholman.com/2017/05/09/scom-management-mp-making-a-scom-admins-life-a-little-easier/
-https://gallery.technet.microsoft.com/SCOM-Agent-Management-b96680d5
+https://github.com/thekevinholman/SCOM.Management
 
 ## SCOM.Management 10.19.10407.3
 

--- a/SCOM.Management/details.json
+++ b/SCOM.Management/details.json
@@ -2,7 +2,7 @@
   "ManagementPackSystemName": "SCOM.Management",
   "ManagementPackDisplayName": "SCOM Management",
   "URL": "https://github.com/thekevinholman/SCOM.Management",
-  "Version": "10.19.10407.3",
+  "Version": "10.19.10552.1",
   "Author": "Kevin Holman",
   "IsFree": true,
   "Description": "Add agent and server role tasks to simply management",

--- a/SCOM.UnsealedMPBackup/details.json
+++ b/SCOM.UnsealedMPBackup/details.json
@@ -1,7 +1,7 @@
 {
   "ManagementPackSystemName": "SCOM.UnsealedMPBackup",
   "ManagementPackDisplayName": "SCOM Unsealed MP Backup",
-  "URL": "https://gallery.technet.microsoft.com/SCOM-2012-and-2016-2ccc45c0",
+  "URL": "https://github.com/thekevinholman/UnsealedMPBackup",
   "Version": "1.0.0.1",
   "Author": "Kevin Holman",
   "IsFree": true,

--- a/Security.Monitoring/ReadMe.md
+++ b/Security.Monitoring/ReadMe.md
@@ -16,26 +16,26 @@
     *   PSExec
     *   Powersploit ([requires additional Power Shell logging GPO](https://nathangau.wordpress.com/2017/05/01/security-monitoring-management-pack-gpo-summary/))
 *   Domain Admin, Enterprise Admin, and Schema Admin Group change monitoring (requires GPO to turn on additional auditing).
-*   [Pass the hash](https://nathangau.wordpress.com/2016/10/14/using-scom-to-detect-successful-pass-the-hash-attacks-part-1/), [overpass the hash](https://nathangau.wordpress.com/2016/10/14/using-scom-to-detect-successful-pass-the-hash-attacks-part-1/), and [pass the ticket](https://nathangau.wordpress.com/2016/12/13/using-scom-to-detect-pass-the-ticket-attacks/) detection.  I ?ve created three rules, and I have enabled one of them.
+*   [Pass the hash](https://nathangau.wordpress.com/2016/10/14/using-scom-to-detect-successful-pass-the-hash-attacks-part-1/), [overpass the hash](https://nathangau.wordpress.com/2016/10/14/using-scom-to-detect-successful-pass-the-hash-attacks-part-1/), and [pass the ticket](https://nathangau.wordpress.com/2016/12/13/using-scom-to-detect-pass-the-ticket-attacks/) detection.  I've created three rules, and I have enabled one of them.
     *   Potential Credential Swap in Progress: Enabled and targeted at all Windows Operating Systems.  This only activates in my lab when using mimikatz to swap credentials.
     *   Potential PtH in progress against tier 1:  Disabled and targeted at all Windows Operating Systems.  This also has an override for domain controllers and SQL servers as it is very noisy otherwise.  If you turn it on, you will probably want to have additional overrides against it (particularly IP address filtering).
     *   Potential PtH in progress against Domain Controllers:  Disabled and targeted at all Windows Domain Controllers.  Consider enabling using IP address filtering for your environment.
 *   Detect clearing of security event logs (event ID 1102) and system event log (event ID 104).
-*   Detect the creation of a service on a domain controller (event ID 7045 in the system log).  I ?ve also created and disabled this same rule targeting windows operating systems. This one would generate some noise under normal conditions, and as such, I ?ve left it off.
+*   Detect the creation of a service on a domain controller (event ID 7045 in the system log).  I've also created and disabled this same rule targeting windows operating systems. This one would generate some noise under normal conditions, and as such, I've left it off.
 *   Detect the creation of services tied to known remote execution tools (event ID 7045)
     *   PSEXECSVC
     *   WINEXE
     *   WCESERVICE
 *   Local account created on a member server (event ID 4720 in security log).  [Requires GPO](https://nathangau.wordpress.com/2017/05/01/security-monitoring-management-pack-gpo-summary/).
 *   Local Admin Group modified on member server (event ID 4732 and 4733).  [Requires GPO](https://nathangau.wordpress.com/2017/05/01/security-monitoring-management-pack-gpo-summary/).
-*   Lynne Taggart ?s [Smart Card change monitor](https://docs.microsoft.com/en-us/archive/blogs/allthat/who-disabled-a-smartcard-for-logon).  I would note that this enabled by default and targeted only to domain controllers.  There are a few differences here. Lynne ?s monitor will reset when the next event is detected where someone enables a smart card. Truthfully, this shouldn ?t happen much in an environment, but I ?m switching this to a rule so that you will see alerts each time a smart card is disabled for interactive logon.
-*   Modified Andres Naranjo ?s composite module to track GPO changes.  My modifications are noted below.
+*   Lynne Taggart's [Smart Card change monitor](https://docs.microsoft.com/en-us/archive/blogs/allthat/who-disabled-a-smartcard-for-logon).  I would note that this enabled by default and targeted only to domain controllers.  There are a few differences here. Lynne's monitor will reset when the next event is detected where someone enables a smart card. Truthfully, this shouldn't happen much in an environment, but I'm switching this to a rule so that you will see alerts each time a smart card is disabled for interactive logon.
+*   Modified Andres Naranjo's composite module to track GPO changes.  My modifications are noted below.
     *   [Part 1](https://nathangau.wordpress.com/2017/04/17/breaking-apart-the-gpo-modification-process-and-using-scom-to-detect-gpo-changes-part-1/)
     *   [Part 2](https://nathangau.wordpress.com/2017/04/19/breaking-apart-the-gpo-modification-process-and-using-scom-to-detect-gpo-changes-part-2/)
 *   Rules sets for known threats that can be [detected off of 4688 events](https://nathangau.wordpress.com/2017/04/20/using-scom-to-capture-suspicious-process-creation-events/).
 *   [Scheduled task creation](https://nathangau.wordpress.com/2017/03/17/using-scom-to-detect-scheduled-task-creation/).  (note that the task scheduler operational log needs to be enabled).
 *   [Golden Ticket detection](https://nathangau.wordpress.com/2017/03/08/using-scom-to-detect-golden-tickets/) (note this requires periodic reset of krgtgt account).
-*   Disabled rule sets (these are off by default.  I don ?t recommend turning them on without some thought and planning).
+*   Disabled rule sets (these are off by default.  I don't recommend turning them on without some thought and planning).
     *   System shut down unexpectedly
     *   System was rebooted
     *   Software was installed on a server
@@ -44,15 +44,15 @@
 
 **Monitors:**
 
-*   Registry Monitor to detect change of UseLogonCredential registry key (for certain [Wdigest attacks](https://nathangau.wordpress.com/2016/12/13/using-scom-to-detect-wdigest-enumeration/)).  I ?m not setting a GPO here because turning this on can break some legacy applications. Note that by disabling the monitor to ignore the noise, you are in essence allowing an attacker to mine clear text passwords out of the LSA.  On the other end, an attacker can potentially set this registry key to a different value to allow them to do it. This monitor would alert you to that possibility.
-*   Registry Monitor to detect the existence of UseLogonCredential registry key.  No key (default setting) allows for exposure of Wdigest credentials in older Windows OS versions.  This is disabled for Server 2012 and Server 2016.  The key does not exist for these Operating Systems but is assumed to be set. I ?m still monitoring in case it is set and set to a different value, but this will reduce noise specific to these OS versions.
-*   Kevin Holman ?s [failed RDP](https://kevinholman.com/2010/04/12/using-opsmgr-for-intrusion-detection-and-security-hardening/) attempts monitor.  I ?ve made some changes to this worth noting:
-    *   The recovery is disabled by default.  I ?d note that the monitor only looks for rapid succession of logon attempts and at the 5th attempt, the recovery will update the firewall to block that IP.  It is, in theory, possible for it to block a legitimate IP if by chance the 5th attempt comes from something legitimate. I don ?t see that happening hardly at all, as it would be a highly improbable event, but worth noting.
+*   Registry Monitor to detect change of UseLogonCredential registry key (for certain [Wdigest attacks](https://nathangau.wordpress.com/2016/12/13/using-scom-to-detect-wdigest-enumeration/)).  I'm not setting a GPO here because turning this on can break some legacy applications. Note that by disabling the monitor to ignore the noise, you are in essence allowing an attacker to mine clear text passwords out of the LSA.  On the other end, an attacker can potentially set this registry key to a different value to allow them to do it. This monitor would alert you to that possibility.
+*   Registry Monitor to detect the existence of UseLogonCredential registry key.  No key (default setting) allows for exposure of Wdigest credentials in older Windows OS versions.  This is disabled for Server 2012 and Server 2016.  The key does not exist for these Operating Systems but is assumed to be set. I'm still monitoring in case it is set and set to a different value, but this will reduce noise specific to these OS versions.
+*   Kevin Holman's [failed RDP](https://kevinholman.com/2010/04/12/using-opsmgr-for-intrusion-detection-and-security-hardening/) attempts monitor.  I've made some changes to this worth noting:
+    *   The recovery is disabled by default.  I'd note that the monitor only looks for rapid succession of logon attempts and at the 5th attempt, the recovery will update the firewall to block that IP.  It is, in theory, possible for it to block a legitimate IP if by chance the 5th attempt comes from something legitimate. I don't see that happening hardly at all, as it would be a highly improbable event, but worth noting.
     *   The alert generation from this is also disabled.
-    *   The reason for disabling the alert is that Brad Watts wrote a module that collects and consolidates 4625 events by the IP address and will generate an alert in that capacity.  You should get an alert for each IP address doing this, allowing you to pass this on to a firewall team to block it at a hardware level or use Kevin ?s recovery if the Windows firewall is in use.
+    *   The reason for disabling the alert is that Brad Watts wrote a module that collects and consolidates 4625 events by the IP address and will generate an alert in that capacity.  You should get an alert for each IP address doing this, allowing you to pass this on to a firewall team to block it at a hardware level or use Kevin's recovery if the Windows firewall is in use.
     *   Reports targeting this solution have also been added so that you can see a reports for failed logon and the IP addresses they are coming from.  While most attackers prefer targeted phishing, this is still useful for those that prefer to kick down the doors the old fashioned way.
 *   System pending restart monitor (disabled by default).
-*   Service monitor for windows event collector service (there ?s also a recovery here to restart it).
+*   Service monitor for windows event collector service (there's also a recovery here to restart it).
 
 **Event Collection (WEF) Monitoring:**
 
@@ -62,32 +62,32 @@
 *   Powersploit use (note this still requires powershell logging. It also requires forwarding these to the event collectors.)
 *   Special Logon in use.  [Event ID 4964 detection](https://docs.microsoft.com/en-us/archive/blogs/jepayne/tracking-lateral-movement-part-one-special-groups-and-specific-service-accounts).  This will generate no noise by default unless you are actively attempting to determine account usage for defined special groups.  More info on this particular event ID [can be found here](https://docs.microsoft.com/en-us/windows/security/threat-protection/auditing/event-4964).
 *   Detect Creation of new service:  This is disabled by default as it would generate noise in most environments.  Consider enabling in an environment where this would not be noisy.
-*   Event ID 4732 or 4733 detection  ? A user added or removed from local admin group.
+*   Event ID 4732 or 4733 detection - A user added or removed from local admin group.
 *   Detect the creation of services tied to remote execution tools (event ID 7045)
     *   PSEXECSVC
     *   WINEXE
     *   WCESERVICE
 *   Pass the Hash Detection
     *   Potential Credential Swap in Progress
-    *   Potential PtH Attack in Progress Against Tier 2  ? Note this is disabled by default since I ?m unable to filter the local host name.  This may generate unwanted noise if turned on.
-*   Prohibited App in Use  ? Event ID 8003 from Applocker
+    *   Potential PtH Attack in Progress Against Tier 2 - Note this is disabled by default since I'm unable to filter the local host name.  This may generate unwanted noise if turned on.
+*   Prohibited App in Use - Event ID 8003 from Applocker
 *   4688 detections.
 
 Should you choose to add additional event forwarding rules, please keep [this article](https://nathangau.wordpress.com/2017/01/11/using-scom-to-capture-events-from-the-forwarded-events-log/) in mind.  They will not work out of the box unless the allow proxying tag is set in XML.
 
 **Views:**
 
-Intrusion Detection Alert View  ? keys in the value  ?Security Monitoring ? in name of all alerts.  All rules also have this value in custom field 10.
+Intrusion Detection Alert View - keys in the value 'Security Monitoring' in name of all alerts.  All rules also have this value in custom field 10.
 
-Threat Hunting Alert View  ? keys in on the value  ?Security Monitoring Threat Hunting ? name in alerts targeted towards detecting practices in need of mitigation.
+Threat Hunting Alert View - keys in on the value 'Security Monitoring Threat Hunting' name in alerts targeted towards detecting practices in need of mitigation.
 
-Event Collector Alert View  ? Displays alerts for items found in the Forwarded Events log.
+Event Collector Alert View - Displays alerts for items found in the Forwarded Events log.
 
-Event Collector State View  ? I only have one health monitor for event collectors and a recovery attached, so if there ?s any red here, they aren ?t working.
+Event Collector State View - I only have one health monitor for event collectors and a recovery attached, so if there's any red here, they aren't working.
 
 **Threat Hunting:**
 
-The purpose of this section is to help you find vulnerabilities in your environment that can be addressed.  Note that this is something that can be a bit noisy.  I have event collection rules defined for these particular events which we can use reports to collect. I ?ve also got alert generating rules defined for these events if you want to respond to alerts.  Alerts that are potentially noisy, I ?ve disabled by default and I recommend that you use SCOM reporting to view this information.
+The purpose of this section is to help you find vulnerabilities in your environment that can be addressed.  Note that this is something that can be a bit noisy.  I have event collection rules defined for these particular events which we can use reports to collect. I've also got alert generating rules defined for these events if you want to respond to alerts.  Alerts that are potentially noisy, I've disabled by default and I recommend that you use SCOM reporting to view this information.
 
 *   Performance Collection:
     *   Event ID 4964

--- a/Security.Monitoring/ReadMe.md
+++ b/Security.Monitoring/ReadMe.md
@@ -2,7 +2,7 @@
 
 *   SQL Management Pack (needed for an override).  Not needed as of v1.0.6.0.
 *   Most of the Server OS MPs (for overrides).
-*   [Windows Event Collector Discovery Management Pack](https://blogs.technet.microsoft.com/nathangau/2017/04/18/windows-event-collector-discovery-management-pack/).
+*   [Windows Event Collector Discovery Management Pack](https://nathangau.wordpress.com/2017/04/18/windows-event-collector-discovery-management-pack/).
 
 **Discoveries:**
 
@@ -10,31 +10,31 @@
 
 **Rule Sets**:
 
-*   App Locker rules ([requires GPO](https://blogs.technet.microsoft.com/nathangau/2017/05/01/security-monitoring-management-pack-gpo-summary/) for applocker rules).
+*   App Locker rules ([requires GPO](https://nathangau.wordpress.com/2017/05/01/security-monitoring-management-pack-gpo-summary/) for applocker rules).
     *   WCE
     *   Mimikatz
     *   PSExec
-    *   Powersploit ([requires additional Power Shell logging GPO](https://blogs.technet.microsoft.com/nathangau/2017/05/01/security-monitoring-management-pack-gpo-summary/))
+    *   Powersploit ([requires additional Power Shell logging GPO](https://nathangau.wordpress.com/2017/05/01/security-monitoring-management-pack-gpo-summary/))
 *   Domain Admin, Enterprise Admin, and Schema Admin Group change monitoring (requires GPO to turn on additional auditing).
-*   [Pass the hash](https://blogs.technet.microsoft.com/nathangau/2016/10/14/using-scom-to-detect-successful-pass-the-hash-attacks-part-1/), [overpass the hash](https://blogs.technet.microsoft.com/nathangau/2016/12/15/using-scom-to-detect-overpass-the-hash-attacks/), and [pass the ticket](https://blogs.technet.microsoft.com/nathangau/2016/12/13/using-scom-to-detect-pass-the-ticket-attacks/) detection.  I ?ve created three rules, and I have enabled one of them.
+*   [Pass the hash](https://nathangau.wordpress.com/2016/10/14/using-scom-to-detect-successful-pass-the-hash-attacks-part-1/), [overpass the hash](https://nathangau.wordpress.com/2016/10/14/using-scom-to-detect-successful-pass-the-hash-attacks-part-1/), and [pass the ticket](https://nathangau.wordpress.com/2016/12/13/using-scom-to-detect-pass-the-ticket-attacks/) detection.  I ?ve created three rules, and I have enabled one of them.
     *   Potential Credential Swap in Progress: Enabled and targeted at all Windows Operating Systems.  This only activates in my lab when using mimikatz to swap credentials.
     *   Potential PtH in progress against tier 1:  Disabled and targeted at all Windows Operating Systems.  This also has an override for domain controllers and SQL servers as it is very noisy otherwise.  If you turn it on, you will probably want to have additional overrides against it (particularly IP address filtering).
     *   Potential PtH in progress against Domain Controllers:  Disabled and targeted at all Windows Domain Controllers.  Consider enabling using IP address filtering for your environment.
 *   Detect clearing of security event logs (event ID 1102) and system event log (event ID 104).
-*   Detect the creation of a service on a domain controller (event ID 7045 in the system log).  I ?ve also created and disabled this same rule targeting windows operating systems. This one would generate some noise under normal conditions, and as such, I ?ve left it off. 
+*   Detect the creation of a service on a domain controller (event ID 7045 in the system log).  I ?ve also created and disabled this same rule targeting windows operating systems. This one would generate some noise under normal conditions, and as such, I ?ve left it off.
 *   Detect the creation of services tied to known remote execution tools (event ID 7045)
     *   PSEXECSVC
     *   WINEXE
     *   WCESERVICE
-*   Local account created on a member server (event ID 4720 in security log).  [Requires GPO](https://blogs.technet.microsoft.com/nathangau/2017/05/01/security-monitoring-management-pack-gpo-summary/).
-*   Local Admin Group modified on member server (event ID 4732 and 4733).  [Requires GPO](https://blogs.technet.microsoft.com/nathangau/2017/05/01/security-monitoring-management-pack-gpo-summary/).
-*   Lynne Taggart ?s [Smart Card change monitor](https://blogs.technet.microsoft.com/allthat/2016/08/07/who-disabled-a-smartcard-for-logon/).  I would note that this enabled by default and targeted only to domain controllers.  There are a few differences here. Lynne ?s monitor will reset when the next event is detected where someone enables a smart card. Truthfully, this shouldn ?t happen much in an environment, but I ?m switching this to a rule so that you will see alerts each time a smart card is disabled for interactive logon. 
+*   Local account created on a member server (event ID 4720 in security log).  [Requires GPO](https://nathangau.wordpress.com/2017/05/01/security-monitoring-management-pack-gpo-summary/).
+*   Local Admin Group modified on member server (event ID 4732 and 4733).  [Requires GPO](https://nathangau.wordpress.com/2017/05/01/security-monitoring-management-pack-gpo-summary/).
+*   Lynne Taggart ?s [Smart Card change monitor](https://docs.microsoft.com/en-us/archive/blogs/allthat/who-disabled-a-smartcard-for-logon).  I would note that this enabled by default and targeted only to domain controllers.  There are a few differences here. Lynne ?s monitor will reset when the next event is detected where someone enables a smart card. Truthfully, this shouldn ?t happen much in an environment, but I ?m switching this to a rule so that you will see alerts each time a smart card is disabled for interactive logon.
 *   Modified Andres Naranjo ?s composite module to track GPO changes.  My modifications are noted below.
-    *   [Part 1](//blogs.technet.microsoft.com/nathangau/2017/04/17/breaking-apart-the-gpo-modification-process-and-using-scom-to-detect-gpo-changes-part-1/)
-    *   [Part 2](//blogs.technet.microsoft.com/nathangau/2017/04/19/breaking-apart-the-gpo-modification-process-and-using-scom-to-detect-gpo-changes-part-2/)
-*   Rules sets for known threats that can be [detected off of 4688 events](https://blogs.technet.microsoft.com/nathangau/2017/04/20/using-scom-to-capture-suspicious-process-creation-events/).
-*   [Scheduled task creation](https://blogs.technet.microsoft.com/nathangau/2017/03/17/using-scom-to-detect-scheduled-task-creation/).  (note that the task scheduler operational log needs to be enabled).
-*   [Golden Ticket detection](https://blogs.technet.microsoft.com/nathangau/2017/03/08/using-scom-to-detect-golden-tickets/) (note this requires periodic reset of krgtgt account).
+    *   [Part 1](https://nathangau.wordpress.com/2017/04/17/breaking-apart-the-gpo-modification-process-and-using-scom-to-detect-gpo-changes-part-1/)
+    *   [Part 2](https://nathangau.wordpress.com/2017/04/19/breaking-apart-the-gpo-modification-process-and-using-scom-to-detect-gpo-changes-part-2/)
+*   Rules sets for known threats that can be [detected off of 4688 events](https://nathangau.wordpress.com/2017/04/20/using-scom-to-capture-suspicious-process-creation-events/).
+*   [Scheduled task creation](https://nathangau.wordpress.com/2017/03/17/using-scom-to-detect-scheduled-task-creation/).  (note that the task scheduler operational log needs to be enabled).
+*   [Golden Ticket detection](https://nathangau.wordpress.com/2017/03/08/using-scom-to-detect-golden-tickets/) (note this requires periodic reset of krgtgt account).
 *   Disabled rule sets (these are off by default.  I don ?t recommend turning them on without some thought and planning).
     *   System shut down unexpectedly
     *   System was rebooted
@@ -44,9 +44,9 @@
 
 **Monitors:**
 
-*   Registry Monitor to detect change of UseLogonCredential registry key (for certain [Wdigest attacks](https://blogs.technet.microsoft.com/nathangau/2016/12/13/using-scom-to-detect-wdigest-enumeration/)).  I ?m not setting a GPO here because turning this on can break some legacy applications. Note that by disabling the monitor to ignore the noise, you are in essence allowing an attacker to mine clear text passwords out of the LSA.  On the other end, an attacker can potentially set this registry key to a different value to allow them to do it. This monitor would alert you to that possibility.
+*   Registry Monitor to detect change of UseLogonCredential registry key (for certain [Wdigest attacks](https://nathangau.wordpress.com/2016/12/13/using-scom-to-detect-wdigest-enumeration/)).  I ?m not setting a GPO here because turning this on can break some legacy applications. Note that by disabling the monitor to ignore the noise, you are in essence allowing an attacker to mine clear text passwords out of the LSA.  On the other end, an attacker can potentially set this registry key to a different value to allow them to do it. This monitor would alert you to that possibility.
 *   Registry Monitor to detect the existence of UseLogonCredential registry key.  No key (default setting) allows for exposure of Wdigest credentials in older Windows OS versions.  This is disabled for Server 2012 and Server 2016.  The key does not exist for these Operating Systems but is assumed to be set. I ?m still monitoring in case it is set and set to a different value, but this will reduce noise specific to these OS versions.
-*   Kevin Holman ?s [failed RDP](https://blogs.technet.microsoft.com/kevinholman/2010/04/12/using-opsmgr-for-intrusion-detection-and-security-hardening/) attempts monitor.  I ?ve made some changes to this worth noting:
+*   Kevin Holman ?s [failed RDP](https://kevinholman.com/2010/04/12/using-opsmgr-for-intrusion-detection-and-security-hardening/) attempts monitor.  I ?ve made some changes to this worth noting:
     *   The recovery is disabled by default.  I ?d note that the monitor only looks for rapid succession of logon attempts and at the 5th attempt, the recovery will update the firewall to block that IP.  It is, in theory, possible for it to block a legitimate IP if by chance the 5th attempt comes from something legitimate. I don ?t see that happening hardly at all, as it would be a highly improbable event, but worth noting.
     *   The alert generation from this is also disabled.
     *   The reason for disabling the alert is that Brad Watts wrote a module that collects and consolidates 4625 events by the IP address and will generate an alert in that capacity.  You should get an alert for each IP address doing this, allowing you to pass this on to a firewall team to block it at a hardware level or use Kevin ?s recovery if the Windows firewall is in use.
@@ -56,11 +56,11 @@
 
 **Event Collection (WEF) Monitoring:**
 
-[Configuration information is here.](https://blogs.technet.microsoft.com/nathangau/2017/05/05/event-forwarding-and-how-to-configure-it-for-the-security-monitoring-management-pack/)  These rules target the Forwarded events logs. It is generally recommended that desktops in particular have events forwarded to event collector servers. A SCOM agent can then be placed on the event collectors to monitor the forwarded event logs.  **This will only work if the event collectors are collecting the events specified in this section**.  I recommend forwarding security events, power shell logging events, Applocker events 8003 or 8004, as well as system event 7045.  [This link](https://technet.microsoft.com/itpro/windows/keep-secure/use-windows-event-forwarding-to-assist-in-instrusion-detection) contains what you need to know about Windows Event Forwarding.  Additional WEF links are [here](http://social.technet.microsoft.com/wiki/contents/articles/33895.windows-event-forwarding.aspx).  Note that most of these rules are configured for Alert Suppression based on logging computer.
+[Configuration information is here.](https://nathangau.wordpress.com/2017/05/05/event-forwarding-and-how-to-configure-it-for-the-security-monitoring-management-pack/)  These rules target the Forwarded events logs. It is generally recommended that desktops in particular have events forwarded to event collector servers. A SCOM agent can then be placed on the event collectors to monitor the forwarded event logs.  **This will only work if the event collectors are collecting the events specified in this section**.  I recommend forwarding security events, power shell logging events, Applocker events 8003 or 8004, as well as system event 7045.  [This link](https://docs.microsoft.com/en-gb/windows/security/threat-protection/use-windows-event-forwarding-to-assist-in-intrusion-detection) contains what you need to know about Windows Event Forwarding.  Additional WEF links are [here](http://social.technet.microsoft.com/wiki/contents/articles/33895.windows-event-forwarding.aspx).  Note that most of these rules are configured for Alert Suppression based on logging computer.
 
 *   Security log cleared (event ID 1102)
 *   Powersploit use (note this still requires powershell logging. It also requires forwarding these to the event collectors.)
-*   Special Logon in use.  [Event ID 4964 detection](https://blogs.technet.microsoft.com/jepayne/2015/11/26/tracking-lateral-movement-part-one-special-groups-and-specific-service-accounts/).  This will generate no noise by default unless you are actively attempting to determine account usage for defined special groups.  More info on this particular event ID [can be found here](https://technet.microsoft.com/en-us/itpro/windows/keep-secure/event-4964).
+*   Special Logon in use.  [Event ID 4964 detection](https://docs.microsoft.com/en-us/archive/blogs/jepayne/tracking-lateral-movement-part-one-special-groups-and-specific-service-accounts).  This will generate no noise by default unless you are actively attempting to determine account usage for defined special groups.  More info on this particular event ID [can be found here](https://docs.microsoft.com/en-us/windows/security/threat-protection/auditing/event-4964).
 *   Detect Creation of new service:  This is disabled by default as it would generate noise in most environments.  Consider enabling in an environment where this would not be noisy.
 *   Event ID 4732 or 4733 detection  ? A user added or removed from local admin group.
 *   Detect the creation of services tied to remote execution tools (event ID 7045)
@@ -73,7 +73,7 @@
 *   Prohibited App in Use  ? Event ID 8003 from Applocker
 *   4688 detections.
 
-Should you choose to add additional event forwarding rules, please keep [this article](https://blogs.technet.microsoft.com/nathangau/2017/01/11/using-scom-to-capture-events-from-the-forwarded-events-log/) in mind.  They will not work out of the box unless the allow proxying tag is set in XML.
+Should you choose to add additional event forwarding rules, please keep [this article](https://nathangau.wordpress.com/2017/01/11/using-scom-to-capture-events-from-the-forwarded-events-log/) in mind.  They will not work out of the box unless the allow proxying tag is set in XML.
 
 **Views:**
 
@@ -94,4 +94,4 @@ The purpose of this section is to help you find vulnerabilities in your environm
     *   Event ID 4624 logon type 4.  This type of logon leaves credentials exposed in the LSA.
     *   Event ID 4672 (disabled by default.  This can generate a lot of events that could cause issues with the DW).
 *   Event ID 4769 result 0x1F.  This can be potentially used in a recovery to detect golden tickets in use in the environment, though to do so, the Kerberos [password will need to be reset twice](http://cert.europa.eu/static/WhitePapers/CERT-EU-SWP_14_07_PassTheGolden_Ticket_v1_1.pdf).  That said, this is a rare event and worth investigating. This will generate alerts.
-*   [Event ID 4964 detection](https://blogs.technet.microsoft.com/jepayne/2015/11/26/tracking-lateral-movement-part-one-special-groups-and-specific-service-accounts/).  This will generate no noise by default unless you are actively attempting to determine account usage for defined special groups.  More info on this particular event ID [can be found here](https://technet.microsoft.com/en-us/itpro/windows/keep-secure/event-4964).
+*   [Event ID 4964 detection](https://docs.microsoft.com/en-gb/archive/blogs/jepayne/tracking-lateral-movement-part-one-special-groups-and-specific-service-accounts).  This will generate no noise by default unless you are actively attempting to determine account usage for defined special groups.  More info on this particular event ID [can be found here](https://docs.microsoft.com/en-us/windows/security/threat-protection/auditing/event-4964).

--- a/Server.Pending.Restart/ReadMe.md
+++ b/Server.Pending.Restart/ReadMe.md
@@ -1,9 +1,9 @@
 #Introduction
-Introducing the ‘Server Pending Restart Monitoring’ management pack for System Center Operations Manager. (2012 R2 / 2016 / 1801 / 1807 / 2019).
+Introducing the ï¿½Server Pending Restart Monitoringï¿½ management pack for System Center Operations Manager. (2012 R2 / 2016 / 1801 / 1807 / 2019).
 
 ##Background:
 
-This management pack was inspired from an existing, and very popular, management pack from David Allen – 'SCOM Pending Reboot Management Pack'. This provides alerting when certain conditions on the monitored server are detected and requires the server to be restarted.
+This management pack was inspired from an existing, and very popular, management pack from David Allen ï¿½ 'SCOM Pending Reboot Management Pack'. This provides alerting when certain conditions on the monitored server are detected and requires the server to be restarted.
 
 We wanted to build on this idea, but at same time, introduce an enhanced level of monitoring.
 
@@ -22,4 +22,5 @@ The monitor is enabled by default and is configured to change the 'Configuration
 The rule, which is disabled by default has the exact same condition detection behaviour as the "Server Pending Restart Monitor". This rule can be enabled as an alternative to the "Server Pending Restart Monitor" when the presentation of health state changes is not required.
 
 ## Resources
-Management Pack guide: https://gallery.technet.microsoft.com/Server-Pending-Restart-New-2457a729/file/220879/1/Server%20Pending%20Restart%20MP%20Guide.pdf
+Management Pack guide: https://web.archive.org/web/20200319004828/https://gallery.technet.microsoft.com/Server-Pending-Restart-New-2457a729/file/221038/1/Server%20Pending%20Restart%20MP%20Guide.pdf
+ReadMe: https://github.com/gavspeed/ServerPendingRestart

--- a/Server.Pending.Restart/ReadMe.md
+++ b/Server.Pending.Restart/ReadMe.md
@@ -22,5 +22,5 @@ The monitor is enabled by default and is configured to change the 'Configuration
 The rule, which is disabled by default has the exact same condition detection behaviour as the "Server Pending Restart Monitor". This rule can be enabled as an alternative to the "Server Pending Restart Monitor" when the presentation of health state changes is not required.
 
 ## Resources
-Management Pack guide: <https://web.archive.org/web/20200319004828/https://gallery.technet.microsoft.com/Server-Pending-Restart-New-2457a729/file/221038/1/Server%20Pending%20Restart%20MP%20Guide.pdf>
+Management Pack guide: <https://web.archive.org/web/20200319004828/https://gallery.technet.microsoft.com/Server-Pending-Restart-New-2457a729/file/221038/1/Server%20Pending%20Restart%20MP%20Guide.pdf>  
 ReadMe: <https://github.com/gavspeed/ServerPendingRestart>

--- a/Server.Pending.Restart/ReadMe.md
+++ b/Server.Pending.Restart/ReadMe.md
@@ -1,9 +1,9 @@
 #Introduction
-Introducing the �Server Pending Restart Monitoring� management pack for System Center Operations Manager. (2012 R2 / 2016 / 1801 / 1807 / 2019).
+Introducing the 'Server Pending Restart Monitoring' management pack for System Center Operations Manager. (2012 R2 / 2016 / 1801 / 1807 / 2019).
 
 ##Background:
 
-This management pack was inspired from an existing, and very popular, management pack from David Allen � 'SCOM Pending Reboot Management Pack'. This provides alerting when certain conditions on the monitored server are detected and requires the server to be restarted.
+This management pack was inspired from an existing, and very popular, management pack from David Allen - 'SCOM Pending Reboot Management Pack'. This provides alerting when certain conditions on the monitored server are detected and requires the server to be restarted.
 
 We wanted to build on this idea, but at same time, introduce an enhanced level of monitoring.
 
@@ -22,5 +22,5 @@ The monitor is enabled by default and is configured to change the 'Configuration
 The rule, which is disabled by default has the exact same condition detection behaviour as the "Server Pending Restart Monitor". This rule can be enabled as an alternative to the "Server Pending Restart Monitor" when the presentation of health state changes is not required.
 
 ## Resources
-Management Pack guide: <https://web.archive.org/web/20200319004828/https://gallery.technet.microsoft.com/Server-Pending-Restart-New-2457a729/file/221038/1/Server%20Pending%20Restart%20MP%20Guide.pdf>  
+Management Pack guide: <https://web.archive.org/web/20200319004828/https://gallery.technet.microsoft.com/Server-Pending-Restart-New-2457a729/file/221038/1/Server%20Pending%20Restart%20MP%20Guide.pdf>
 ReadMe: <https://github.com/gavspeed/ServerPendingRestart>

--- a/Server.Pending.Restart/ReadMe.md
+++ b/Server.Pending.Restart/ReadMe.md
@@ -22,5 +22,5 @@ The monitor is enabled by default and is configured to change the 'Configuration
 The rule, which is disabled by default has the exact same condition detection behaviour as the "Server Pending Restart Monitor". This rule can be enabled as an alternative to the "Server Pending Restart Monitor" when the presentation of health state changes is not required.
 
 ## Resources
-Management Pack guide: https://web.archive.org/web/20200319004828/https://gallery.technet.microsoft.com/Server-Pending-Restart-New-2457a729/file/221038/1/Server%20Pending%20Restart%20MP%20Guide.pdf
-ReadMe: https://github.com/gavspeed/ServerPendingRestart
+Management Pack guide: <https://web.archive.org/web/20200319004828/https://gallery.technet.microsoft.com/Server-Pending-Restart-New-2457a729/file/221038/1/Server%20Pending%20Restart%20MP%20Guide.pdf>
+ReadMe: <https://github.com/gavspeed/ServerPendingRestart>

--- a/Server.Pending.Restart/ReadMe.md
+++ b/Server.Pending.Restart/ReadMe.md
@@ -1,7 +1,8 @@
-#Introduction
+# Introduction
+
 Introducing the 'Server Pending Restart Monitoring' management pack for System Center Operations Manager. (2012 R2 / 2016 / 1801 / 1807 / 2019).
 
-##Background:
+## Background
 
 This management pack was inspired from an existing, and very popular, management pack from David Allen - 'SCOM Pending Reboot Management Pack'. This provides alerting when certain conditions on the monitored server are detected and requires the server to be restarted.
 
@@ -10,6 +11,7 @@ We wanted to build on this idea, but at same time, introduce an enhanced level o
 This management pack provides monitoring and alerting for multiple pending restart conditions. Each condition check can enabled / disabled via override to suit your monitoring requirements.
 
 Pending restart condition detection:
+
 * Component Based Servicing (CBS)
 * Pending Computer Rename and/or Domain Join operations
 * Pending File Rename Operations
@@ -22,5 +24,6 @@ The monitor is enabled by default and is configured to change the 'Configuration
 The rule, which is disabled by default has the exact same condition detection behaviour as the "Server Pending Restart Monitor". This rule can be enabled as an alternative to the "Server Pending Restart Monitor" when the presentation of health state changes is not required.
 
 ## Resources
+
 Management Pack guide: <https://web.archive.org/web/20200319004828/https://gallery.technet.microsoft.com/Server-Pending-Restart-New-2457a729/file/221038/1/Server%20Pending%20Restart%20MP%20Guide.pdf>
 ReadMe: <https://github.com/gavspeed/ServerPendingRestart>

--- a/System.Center.Operations.Manager.Health.Check.Reports/details.json
+++ b/System.Center.Operations.Manager.Health.Check.Reports/details.json
@@ -1,7 +1,7 @@
 {
     "ManagementPackSystemName":  "System.Center.Operations.Manager.Health.Check.Reports",
     "ManagementPackDisplayName":  "System Center Operations Manager Health Check Reports",
-    "URL":  "https://gallery.technet.microsoft.com/SCOM-Health-Check-Reports-c32e8f93",
+    "URL":  "https://web.archive.org/web/20210120112124/https://gallery.technet.microsoft.com/SCOM-Health-Check-Reports-c32e8f93",
     "Version":  "3.0.1.5",
     "Author":  "Oskar Landman",
     "Description":  "This management pack bundle is an update to the famous SCC Health Check reports posted back in 2010.",

--- a/TCPPortMonitoring.ManagementPack/ReadMe.md
+++ b/TCPPortMonitoring.ManagementPack/ReadMe.md
@@ -1,14 +1,14 @@
-### **Create 100's of TCP monitors in minutes with?SCOM**
+### **Create 100's of TCP monitors in minutes with SCOM**
 
 **By Jasper Van Damme**
 
 As you may or may not know, creating TCP monitors in SCOM through use of the template is a fairly time intensive task, especially if you have to create a ton of TCP monitors. Furthermore, templates are fine for smaller scale Operations Manager environments but tend to create a lot of unnecessary groups, overrides, views etc.
 
-So naturally I was looking for a more elegant solution as I did not want to go through creating 100's TCP monitors. My first thought was to google if anything exists already, and to my surprise, I did not find any immediate solutions. What I did find however was the following?[post](https://azurecloudai.blog/2015/12/01/scom-advanced-authoring-powershell-discovery-from-csv-file-explained-using-tcp-port-monitoring-scenario/)?(credits to?[Gowdhaman Karthikeyan](https://social.technet.microsoft.com/profile/Gowdhaman+Karthikeyan)).[\
+So naturally I was looking for a more elegant solution as I did not want to go through creating 100's TCP monitors. My first thought was to google if anything exists already, and to my surprise, I did not find any immediate solutions. What I did find however was the following [post](https://azurecloudai.blog/2015/12/01/scom-advanced-authoring-powershell-discovery-from-csv-file-explained-using-tcp-port-monitoring-scenario/) (credits to [Gowdhaman Karthikeyan](https://social.technet.microsoft.com/profile/Gowdhaman+Karthikeyan)).[\
 ](https://azurecloudai.blog/2015/12/01/scom-advanced-authoring-powershell-discovery-from-csv-file-explained-using-tcp-port-monitoring-scenario/)\
-This post explains how you can use a PowerShell discovery with a comma separated file or 'CSV' to?add the proper TCP Port instances in SCOM. This has some significant advantages over using the template (as outlined in the blog post):
+This post explains how you can use a PowerShell discovery with a comma separated file or 'CSV' to add the proper TCP Port instances in SCOM. This has some significant advantages over using the template (as outlined in the blog post):
 
--   You can let other?teams add TCP monitors themselves, with minimum SCOM knowledge or access
+-   You can let other teams add TCP monitors themselves, with minimum SCOM knowledge or access
 -   It is more scalable, as it does not create any unnecessary groups, overrides, views compared to the template
 -   It is a lot faster, as you dont have to go through the template for each TCP monitor you want to create
 -   The information is centrally stored in the CSV

--- a/TCPPortMonitoring.ManagementPack/ReadMe.md
+++ b/TCPPortMonitoring.ManagementPack/ReadMe.md
@@ -4,8 +4,8 @@
 
 As you may or may not know, creating TCP monitors in SCOM through use of the template is a fairly time intensive task, especially if you have to create a ton of TCP monitors. Furthermore, templates are fine for smaller scale Operations Manager environments but tend to create a lot of unnecessary groups, overrides, views etc.
 
-So naturally I was looking for a more elegant solution as I did not want to go through creating 100's TCP monitors. My first thought was to google if anything exists already, and to my surprise, I did not find any immediate solutions. What I did find however was the following?[post](https://blogs.technet.microsoft.com/meamcs/2015/12/01/scom-advanced-authoring-powershell-discovery-from-csv-file-explained-using-tcp-port-monitoring-scenario/)?(credits to?[Gowdhaman Karthikeyan](https://social.technet.microsoft.com/profile/Gowdhaman+Karthikeyan)).[\
-](https://blogs.technet.microsoft.com/meamcs/2015/12/01/scom-advanced-authoring-powershell-discovery-from-csv-file-explained-using-tcp-port-monitoring-scenario/)\
+So naturally I was looking for a more elegant solution as I did not want to go through creating 100's TCP monitors. My first thought was to google if anything exists already, and to my surprise, I did not find any immediate solutions. What I did find however was the following?[post](https://azurecloudai.blog/2015/12/01/scom-advanced-authoring-powershell-discovery-from-csv-file-explained-using-tcp-port-monitoring-scenario/)?(credits to?[Gowdhaman Karthikeyan](https://social.technet.microsoft.com/profile/Gowdhaman+Karthikeyan)).[\
+](https://azurecloudai.blog/2015/12/01/scom-advanced-authoring-powershell-discovery-from-csv-file-explained-using-tcp-port-monitoring-scenario/)\
 This post explains how you can use a PowerShell discovery with a comma separated file or 'CSV' to?add the proper TCP Port instances in SCOM. This has some significant advantages over using the template (as outlined in the blog post):
 
 -   You can let other?teams add TCP monitors themselves, with minimum SCOM knowledge or access

--- a/s2.OperationsManager.Trace.Helper/ReadMe.md
+++ b/s2.OperationsManager.Trace.Helper/ReadMe.md
@@ -17,10 +17,10 @@ The tasks are in the right order as they are supposed to be performed. That is w
 "Copy new Trace" expects a hidden share named "scom$" on the Management or Gateway Server the agent is managed from. You have to give "Domain Computers" write permissions to the share and the folder as well. If the agent is running with an user account, you have to give this user the permissions.
 
 **Updates:**
-14.06.2018: added workflow traces ([Requires override](https://blogs.technet.microsoft.com/momteam/2013/10/31/how-to-analyze-a-workflow-when-the-opsmgr-workflow-analyzer-doesnt-work/))
+14.06.2018: added workflow traces ([Requires override](https://techcommunity.microsoft.com/t5/system-center-blog/how-to-analyze-a-workflow-when-the-opsmgr-workflow-analyzer/ba-p/348590))
 
 
 ## Resources:
 
-*   https://gallery.technet.microsoft.com/MP-SCOM-Trace-Helper-Tasks-70380ca4
-*   https://blogs.technet.microsoft.com/momteam/2013/10/31/how-to-analyze-a-workflow-when-the-opsmgr-workflow-analyzer-doesnt-work/
+*   https://web.archive.org/web/20200318062142/https://gallery.technet.microsoft.com/MP-SCOM-Trace-Helper-Tasks-70380ca4
+*   https://techcommunity.microsoft.com/t5/system-center-blog/how-to-analyze-a-workflow-when-the-opsmgr-workflow-analyzer/ba-p/348590

--- a/s2.OperationsManager.Trace.Helper/details.json
+++ b/s2.OperationsManager.Trace.Helper/details.json
@@ -1,7 +1,7 @@
 {
   "ManagementPackSystemName": "s2.OperationsManager.Trace.Helper",
   "ManagementPackDisplayName": "s2.OperationsManager.Trace.Helper",
-  "URL": "https://gallery.technet.microsoft.com/MP-SCOM-Trace-Helper-Tasks-70380ca4",
+  "URL": "https://web.archive.org/web/20200318062142/https://gallery.technet.microsoft.com/MP-SCOM-Trace-Helper-Tasks-70380ca4",
   "Version": "1.0.0.21",
   "Author": "Patrick Seidl (s2)",
   "IsFree": true,


### PR DESCRIPTION
Thanks for helping contribute to the MP Catalog.  Please check the contribution guidelines with any questions, then fill out the below blanks.

What does this add/fix? 
------------------------------
TechNet is basically dead. This replaces broken TechNet links where better ones exist.
Where redirects are in place I've added the endpoints.
Where I know of better places to find the content than the redirect (e.g. moves to self-hosted blogs) I've added those instead.
Where no better solution exists I've used the Wayback machine.
Miscellaneous markdown bits that VS was complaining about.
Fixes to things like apostrophes and hyphens that have been dropped at some point.
…

Does this close any currently open issues?
------------------------------------------
Mitigates #116
Not really a full fix though, I lean on the Wayback machine far more than I would like.
…

Any other comments?
-------------------
There is one set of links (around event 4964) where it is unclear exactly what to expect out of the end link. I think I've replaced this correctly, but am unsure as there is not enough context for me to evaluate if I'm correct or not (link 404s, Wayback machine never crawled, not in a link format that I know how to reverse engineer new hosting for).
If anyone can confirm or replace this I'd be grateful.
…